### PR TITLE
Addition of future as dependency and fix in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ target/
 # Cython Generated files
 grakel/kernels/_c_functions.cpython-35m-x86_64-linux-gnu.so
 grakel/kernels/_c_functions/functions.cpp
+grakel/kernels/_isomorphism/bliss.cpp

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The grakel library requires:
 * SciPy [>= 0.13.3]
 * Cython [>= 0.27.3]
 * cvxopt [>= 1.2.0] [optional: lovasz]
+* future [>=0.16.0] (for python 2.7)
 
 For installing dependencies the procedure is the well known:
 ```shell
@@ -36,6 +37,12 @@ To learn how to use the GraKeL api **as a user**, please read the [documentation
 
 Testing
 =======
+In order for the following to work you first need to build the package cython extension
+locally by executing:
+```shell
+$ python setup.py build_ext -i
+```
+
 To test the package, execute:
 ```shell
 $ nosetests
@@ -102,11 +109,6 @@ optional arguments:
 You can also execute the kernel test locally through a *test-main-function* as
 ```shell
 $ python -m grakel.tests
-```
-but in order for this to work you would need first to build the package cython extension
-locally by executing:
-```shell
-$ python setup.py build_ext -i
 ```
 
 Contributing

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy>=1.0.1
 cython>=0.27.3
 future>=0.16.0
 six>=1.11.0
+future>=0.16.0


### PR DESCRIPTION
Hi guys,

I've just installed your library and I came across a couple of issues. Firstly future should be a dependency since it's been used when trying to run the library with python2. Secondly the text in README.md that says that we should first build the cython extension should be at the beginning of the section. There's few people that are going to find that at the bottom! (I've actually spent 10min looking around why it wasn't working until I checked again and found that bit).

Thanks for the library! I saw the list of kernels and seems awesome :).

Best,
Roberto.