### PR TITLE
Faster "calculation" stage for Floyd-Warshall

### DIFF
--- a/grakel/graph.py
+++ b/grakel/graph.py
@@ -1720,10 +1720,8 @@ def floyd_warshall(adjacency_matrix):
     np.fill_diagonal(dist, 0)
 
     # Calculation
-    for k in range(0, n):
-        for i in range(0, n):
-            for j in range(0, n):
-                if (dist[i, j] > dist[i, k] + dist[k, j]):
-                    dist[i, j] = dist[i, k] + dist[k, j]
+    for k in range(adjacency_matrix.shape[0]):
+        for i in range(adjacency_matrix.shape[0]):
+            dist[i, :] = np.minimum(dist[i, :], dist[i, k] + dist[k, :])
 
     return dist

--- a/grakel/graph.py
+++ b/grakel/graph.py
@@ -1713,15 +1713,14 @@ def floyd_warshall(adjacency_matrix):
     """
     n = adjacency_matrix.shape[0]
 
-    dist = np.empty((n, n))
     # Initialization
     dist = copy.deepcopy(adjacency_matrix)
     dist[dist == 0] = float("Inf")
     np.fill_diagonal(dist, 0)
 
     # Calculation
-    for k in range(adjacency_matrix.shape[0]):
-        for i in range(adjacency_matrix.shape[0]):
+    for k in range(n):
+        for i in range(n):
             dist[i, :] = np.minimum(dist[i, :], dist[i, k] + dist[k, :])
 
     return dist


### PR DESCRIPTION
Hi ysig.

Following Issue #27 and following PR #29 I found a way also to speedup significantly the "Calculation" stage for Floyd-Warshall (in PR #29 only the "Initialization" stage was involved).

Briefly, instead of running a triple-nested for-loop, only 2 for-loops are involved + a vectorised statement.

I have been comparing your `floyd_warshall()` function against the fully vectorised one (PR #29 and this PR) on a Linux 19.10 machine with an Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz and these are my results.

Dataset AIDS (entire dataset):

- previous version: 23.5 seconds

- vectorised version: 4.9 seconds

Dataset COX2 (entire dataset):

- previous version: 20.5 seconds

- vectorised version: 4.6 seconds

Dataset MSRC_9 (entire dataset):

- previous version: 116.1 seconds

- vectorised version: 24.9 seconds

Dataset MUTAG (entire dataset):

- previous version: 0.86 seconds

- vectorised version: 0.37 seconds

Dataset DD (first 20 graphs only):

- previous version: 45125.30 seconds

- vectorised version: 286.09 seconds

Needless to say, the two routines return the very same shortest path matrix.