### PR TITLE
Changed import of Bunch

### DIFF
--- a/grakel/utils.py
+++ b/grakel/utils.py
@@ -14,7 +14,7 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import ShuffleSplit
 from sklearn.base import BaseEstimator
 from sklearn.svm import SVC
-from sklearn.datasets.lfw import Bunch
+from sklearn.utils import Bunch
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted
 


### PR DESCRIPTION
Continuing #47 

I've looked into it and my change doesn't brake compatibility with older sklearn.

The old import is rather weird - instead of importing Bunch directly from sklearn.utils, Bunch is imported from sklearn.datasets.lfw which it self imports it from sklearn,utils. (grakel.datasets.base does the import directly)

But https://github.com/scikit-learn/scikit-learn/commit/4a95e33e6344e15a197f33ddc2f8f786a0a45df0#diff-69a94044cca2c315ebd6831b42ed883f7984b4cdba5f446946ba15a248689a07 this commit made the modules in dataset package private (file name changed from x to _x) raising this deprecation warning 

"The sklearn.datasets.lfw module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.datasets. Anything that cannot be imported from sklearn.datasets is now part of the private API."

I used Grakel with the master branch of sklearn which sets the version to 0.24,dev0 so, I only come across this by chance, but at least you have one less thing to care about  when 0.24 comes out, if you accept this change.
