### PR TITLE
Add newer python versions to builds

### DIFF
--- a/.conda_build.sh
+++ b/.conda_build.sh
@@ -6,4 +6,8 @@ conda build purge
 conda-build . --output-folder conda_build/ --python 2.7
 conda-build . --output-folder conda_build/ --python 3.5
 conda-build . --output-folder conda_build/ --python 3.6
+conda-build . --output-folder conda_build/ --python 3.7
+conda-build . --output-folder conda_build/ --python 3.8
+conda-build . --output-folder conda_build/ --python 3.9
+conda-build . --output-folder conda_build/ --python 3.10
 conda convert -f --platform all conda_build/linux-64/*.tar.bz2 -o conda_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,80 +23,101 @@ env:
 
 matrix:
   include:
+    # Linux
     - sudo: required
       services:
         - docker
       env:
-        - PIP=pip
-        - PYTHON=python
-        - CIBW_BUILD="cp37-manylinux_x86_64"
-        - COVERAGE="true"
-        - DEPLOY_SDIST="true"
-    - sudo: required
-      services:
-        - docker
-      env:
-        - PIP=pip
-        - PYTHON=python
         - CIBW_BUILD="cp35-manylinux_x86_64"
-        - FLAKE="true"
     - sudo: required
       services:
         - docker
       env:
-        - PIP=pip
-        - PYTHON=python
         - CIBW_BUILD="cp36-manylinux_x86_64"
     - sudo: required
       services:
         - docker
       env:
-        - PIP=pip
-        - PYTHON=python
+        - CIBW_BUILD="cp37-manylinux_x86_64"
+        - DEPLOY_SDIST="true"
+    - sudo: required
+      services:
+        - docker
+      env:
+        - CIBW_BUILD="cp38-manylinux_x86_64"
+    - sudo: required
+      services:
+        - docker
+      env:
+        - CIBW_BUILD="cp39-manylinux_x86_64"
+    - sudo: required
+      services:
+        - docker
+      env:
+        - CIBW_BUILD="cp310-manylinux_x86_64"
+        - COVERAGE="true"
+        - FLAKE="true"
+    - sudo: required
+      services:
+        - docker
+      env:
         - CIBW_BUILD="cp27-manylinux1_x86_64"
     - sudo: required
       services:
         - docker
       env:
-        - PIP=pip
-        - PYTHON=python
         - CIBW_BUILD="cp27-manylinux1_i686"
+
+    # OSX
     - os: osx
       language: generic
       sudo: required
       env:
-        - TOXENV=py35
-        - PIP=pip3
-        - PYTHON=python3
         - CIBW_BUILD="cp27-macosx_10_6_intel"
     - os: osx
       language: generic
       sudo: required
       env:
-        - PIP=pip3
-        - PYTHON=python3
-        - TOXENV=py35
         - CIBW_BUILD="cp35-macosx_10_6_intel"
     - os: osx
       language: generic
       sudo: required
       env:
-        - PIP=pip3
-        - PYTHON=python3
-        - TOXENV=py35
         - CIBW_BUILD="cp36-macosx_10_6_intel"
     - os: osx
       language: generic
       sudo: required
       env:
-        - PIP=pip3
-        - PYTHON=python3
-        - TOXENV=py35
         - CIBW_BUILD="cp37-macosx_10_6_intel"
+    - os: osx
+      language: generic
+      sudo: required
+      env:
+        - CIBW_BUILD="cp38-macosx_10_6_intel"
+    - os: osx
+      language: generic
+      sudo: required
+      env:
+        - CIBW_BUILD="cp39-macosx_10_6_intel"
+    - os: osx
+      language: generic
+      sudo: required
+      env:
+        - CIBW_BUILD="cp310-macosx_10_6_intel"
+
 script:
   - |
     if [[ "$FLAKE" == "true" ]]; then
         $PIP install flake8 --upgrade; flake8 $TRAVIS_BUILD_DIR/grakel;
+    fi
+  - |
+    # If it's a python 3 build, use python 3 stuff
+    if [[ "$CIBW_BUILD" =~ ^cp3.* ]]; then
+      PIP=pip3
+      PYTHON=python3
+    else
+      PIP=pip
+      PYTHON=python
     fi
   - $PIP install cibuildwheel
   - export CIBW_ENVIRONMENT="TEST_DIR=$TEST_DIR MODULE=$MODULE COVERAGE=$COVERAGE CODECOV_TOKEN=$CODECOV_TOKEN";

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - MODULE=grakel
     - WHEEL_FOLDER=wheelhouse
     - TWINE_USERNAME=ysig
-    - DEPLOY_SDIST="false"
+    - DEPLOY_SDIST="true"
     - COVERAGE="false"
     - DEPLOY_WHEEL="true"
     - FLAKE="false"
@@ -39,7 +39,6 @@ matrix:
         - docker
       env:
         - CIBW_BUILD="cp37-manylinux_x86_64"
-        - DEPLOY_SDIST="true"
     - sudo: required
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - MODULE=grakel
     - WHEEL_FOLDER=wheelhouse
     - TWINE_USERNAME=ysig
-    - DEPLOY_SDIST="true"
+    - DEPLOY_SDIST="false"
     - COVERAGE="false"
     - DEPLOY_WHEEL="true"
     - FLAKE="false"
@@ -39,6 +39,7 @@ matrix:
         - docker
       env:
         - CIBW_BUILD="cp37-manylinux_x86_64"
+        - DEPLOY_SDIST="true"
     - sudo: required
       services:
         - docker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,21 @@ environment:
       MINICONDA: "C:\\Miniconda37-x64"
       DEPLOY_WHEEL: "true"
 
+    - PYTHON_VERSION: "3.8.5"
+      PYTHON_ARCH: "64"
+      MINICONDA: "C:\\Miniconda38-x64"
+      DEPLOY_WHEEL: "true"
+
+    - PYTHON_VERSION: "3.9.14"
+      PYTHON_ARCH: "64"
+      MINICONDA: "C:\\Miniconda39-x64"
+      DEPLOY_WHEEL: "true"
+
+    - PYTHON_VERSION: "3.10.7"
+      PYTHON_ARCH: "64"
+      MINICONDA: "C:\\Miniconda310-x64"
+      DEPLOY_WHEEL: "true"
+
 install:
   # Initialise conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"


### PR DESCRIPTION
I tried to add `cp38`, `cp39`, `cp310` to the builds.

I moved the coverage and flake8 checks to be on the latest python version.

I also cleaned up the script a tiny bit by removing redundancy, makes it a bit easier to read:
* `PIP` and `PYTHON` can be gotten by the `CIBW_BUILD` parameter
* I removed the `TOXENV` environment variable, I can't find any mention of it in the repo or on travisci docs. If it breaks, I can add it back in, seems to only be for MaxOSX.

I'm not going to try add windows because I have no way to test this.

---
Regarding testing it, I guess the easiest way is to create a new branch and I can target the PR to there? I really don't know how.
