### PR TITLE
Remove win32 builds altogether

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,14 +72,15 @@ jobs:
           CIBW_BUILD: ${{ matrix.py }}
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_WINDOWS: AMD64 x86
+          # No win32 ("x86") for Windows as scipy declared it has stopped releasing wheels
+          # from 1.8.0 onwards, officially from 1.9.3
+          CIBW_ARCHS_WINDOWS: AMD64
           # Install test requirements and run the test-cmd
           CIBW_TEST_EXTRAS: ${{ env.extra-requires }}
           # {project} is a special string recognized by CIBW and replaced with the project dir
           CIBW_TEST_COMMAND: ${{ env.test-cmd }} {project}
-          # * Scipy has stopped releasing win32 builds from python 3.10 onwards
           # * Scipy has no wheels released for musllinux and will not build because OpenBLAS is not found
-          CIBW_SKIP: "cp310-win32 *-musllinux*"
+          CIBW_SKIP: "*-musllinux*"
           # https://cibuildwheel.readthedocs.io/en/stable/options/#test-skip
           # * Will avoid testing on emulated architectures (aarch64)
           # * Skip trying to test arm64 builds on Intel Macs


### PR DESCRIPTION
tldr; Fully dropped building prebuilt binaries for `win32` because scipy finally did it too, they said they would a while ago but only fully did it 2 days back.

---
So it seems that Scipy updated to `1.9.2` 2 days ago (08/10/22) and as part of that, they stopped releasing `win32` completely. This meant when building `GraKeL`, it would download the source of `scipy` and try to compile it manually.

Ctrl + f for `win32` and you'll see they dropped it between the two versions
* [Wheels for 1.9.2](https://pypi.org/project/scipy/1.9.2/#files)
* [Wheels for 1.9.1](https://pypi.org/project/scipy/1.9.1/#files)

It seems odd they would drop it with a minor release so I went looking at their github.

One issue specifically asks about `Python 3.10` which I had disabled previously but one of the maintainers [replied in there, saying they would drop `win32` wheels from `scipy>=1.8`](https://github.com/scipy/scipy/issues/15836). There was however, still `win32` wheels available from `1.8.0 -> 1.9.1`.

There is also an [issue](https://github.com/scipy/scipy/issues/15836) from 2 days ago where they apparently stated they updated their build infrastructure which I guess is where they finally dropped it. [Looking at the workflow runs they linked in that issue](https://github.com/scipy/scipy/actions/runs/3211264776), there's no build for `win32` at all so I guess from this point on it's fully dropped support for pre-built `win32` wheels.

So the choices are essentially (in order of recommendation):
* To roll with `scipy` and just follow their lead on dropping `win32` wheels
* To upperbound `scipy<=1.9.1`
* To somehow install the toolchain needed to get `scipy` to build on github action servers.
    * If it were simple, scipy would just do it themselves
    * ...How da heck do you compile their underlying FORTRAN?
 
I went with the first because, well, it's easiest and upperbounding will lead to similar problems in the future, someone want's GraKeL and the newest scikit learn, and they will both have conflicting scipy versions.

---


