### PR TITLE
fix when graph grakel is initialized with attributes 

### DIFF
--- a/grakel/kernels/edge_histogram.py
+++ b/grakel/kernels/edge_histogram.py
@@ -96,7 +96,11 @@ class EdgeHistogram(Kernel):
                         continue
                     else:
                         # Our element is an iterable of at least 2 elements
-                        L = x[2]
+                        elements = list(itervalues( x[2] ))
+                        if( isinstance( elements[0], Iterable) ):
+                            L = list( map( lambda y: y[0], elements ))
+                        else:
+                            L = elements
                 elif type(x) is Graph:
                     # get labels in any existing format
                     L = x.get_labels(purpose="any", label_type="edge")
@@ -107,7 +111,7 @@ class EdgeHistogram(Kernel):
                                     'dict \n')
 
                 # construct the data input for the numpy array
-                for (label, frequency) in iteritems(Counter(itervalues(L))):
+                for (label, frequency) in iteritems(Counter( L )):
                     # for the row that corresponds to that graph
                     rows.append(ni)
 

--- a/grakel/kernels/vertex_histogram.py
+++ b/grakel/kernels/vertex_histogram.py
@@ -96,7 +96,11 @@ class VertexHistogram(Kernel):
                         continue
                     else:
                         # Our element is an iterable of at least 2 elements
-                        L = x[1]
+                        elements = list(itervalues( x[1] ))
+                        if( isinstance( elements[0], Iterable) ):
+                            L = list( map( lambda y: y[0], elements ))
+                        else:
+                            L = elements
                 elif type(x) is Graph:
                     # get labels in any existing format
                     L = x.get_labels(purpose="any")
@@ -107,7 +111,7 @@ class VertexHistogram(Kernel):
                                     'dict \n')
 
                 # construct the data input for the numpy array
-                for (label, frequency) in iteritems(Counter(itervalues(L))):
+                for (label, frequency) in iteritems(Counter( L )):
                     # for the row that corresponds to that graph
                     rows.append(ni)
 

--- a/grakel/kernels/weisfeiler_lehman.py
+++ b/grakel/kernels/weisfeiler_lehman.py
@@ -178,7 +178,16 @@ class WeisfeilerLehman(Kernel):
                 Gs_ed[nx] = x.get_edge_dictionary()
                 L[nx] = x.get_labels(purpose="dictionary")
                 extras[nx] = extra
-                distinct_values |= set(itervalues(L[nx]))
+                elements = list(itervalues(L[nx]))
+                if( isinstance( elements[0], Iterable) ):
+                    el = list( map( lambda y: y[0], elements ))
+                else:
+                    el = elements
+                temp={}
+                for k,v in zip( list(L[nx].keys()), el):
+                    temp[k] = v
+                L[nx] = temp 
+                distinct_values |= set( el )
                 nx += 1
             if nx == 0:
                 raise ValueError('parsed input is empty')
@@ -357,10 +366,18 @@ class WeisfeilerLehman(Kernel):
                                          'least one and at most 3 elements\n')
                     Gs_ed[nx] = x.get_edge_dictionary()
                     L[nx] = x.get_labels(purpose="dictionary")
-
+                    elements = list(itervalues( L[nx] ))
+                    if( isinstance( elements[0], Iterable) ):
+                        el = list( map( lambda y: y[0], elements ))
+                    else:
+                        el = elements
+                    temp={}
+                    for k,v in zip( list(L[nx].keys()), el):
+                        temp[k] = v
+                    L[nx] = temp
                     # Hold all the distinct values
                     distinct_values |= set(
-                        v for v in itervalues(L[nx])
+                        v for v in el
                         if v not in self._inv_labels[0])
                     nx += 1
                 if nx == 0:


### PR DESCRIPTION
Treatment to check existence of attributes when Vertex or Edge histogram are called as well as WeisfeilerLehman, because in the main branch, currently, when a graph has more attributes than the label it raises an error and stops.