### PR TITLE
make RandomWalk kernel compatible with ScyPi version >= 1.12.0

### DIFF
--- a/grakel/kernels/random_walk.py
+++ b/grakel/kernels/random_walk.py
@@ -268,7 +268,7 @@ class RandomWalk(Kernel):
             # A*x=b
             A = LinearOperator((mn, mn), matvec=lambda x: lsf(x, self.lamda))
             b = np.ones(mn)
-            x_sol, _ = cg(A, b, tol=1.0e-6, maxiter=20, atol='legacy')
+            x_sol, _ = cg(A, b, rtol=1.0e-6, maxiter=20)
             return np.sum(x_sol)
 
 
@@ -467,7 +467,7 @@ class RandomWalkLabeled(RandomWalk):
             # A*x=b
             A = LinearOperator((mn, mn), matvec=lambda x: lsf(x, self.lamda))
             b = np.ones(mn)
-            x_sol, _ = cg(A, b, tol=1.0e-6, maxiter=20, atol='legacy')
+            x_sol, _ = cg(A, b, rtol=1.0e-6, maxiter=20)
             return np.sum(x_sol)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.14.0
 cython>=0.27.3
 scikit-learn>=0.19
+scipy>=1.12.0
 six>=1.11.0
 future>=0.16.0
 joblib


### PR DESCRIPTION
This PR fixes #111. Deprecated argument `tol` in function `scipy.sparse.linalg.cg` was removed in version 1.14.0 [[1](https://docs.scipy.org/doc/scipy-1.13.1/reference/generated/scipy.sparse.linalg.cg.html)]. Minimal compatible version of ScyPi is now 1.12.0.