### PR TITLE
explicitly define dtype for sparse matrix

### DIFF
--- a/grakel/kernels/vertex_histogram.py
+++ b/grakel/kernels/vertex_histogram.py
@@ -132,7 +132,12 @@ class VertexHistogram(Kernel):
                     self.sparse_ = bool(self.sparse)
 
             if self.sparse_:
-                features = csr_matrix((data, (rows, cols)), shape=(ni, len(labels)), copy=False)
+                features = csr_matrix(
+                    (data, (rows, cols)),
+                    shape=(ni, len(labels)),
+                    copy=False,
+                    dtype=">f8",
+                )
             else:
                 # Initialise the feature matrix
                 try:
@@ -140,7 +145,12 @@ class VertexHistogram(Kernel):
                     features[rows, cols] = data
                 except MemoryError:
                     warn('memory-error: switching to sparse')
-                    self.sparse_, features = True, csr_matrix((data, (rows, cols)), shape=(ni, len(labels)), copy=False)
+                    self.sparse_, features = True, csr_matrix(
+                        (data, (rows, cols)),
+                        shape=(ni, len(labels)),
+                        copy=False,
+                        dtype=">f8",
+                    )
 
             if ni == 0:
                 raise ValueError('parsed input is empty')


### PR DESCRIPTION
Fix issue #113 by setting the datatype to float during sparse matrix initialization.