### PR TITLE
fix: scalar output in SubgraphMatching

### DIFF
--- a/grakel/kernels/subgraph_matching.py
+++ b/grakel/kernels/subgraph_matching.py
@@ -140,7 +140,7 @@ class SubgraphMatching(Kernel):
 
         """
         tv = sm_kernel(x, y, self.kv, self.ke, self.k)
-        return np.dot(self.lambdas_, tv)
+        return np.dot(self.lambdas_.flat, tv)
 
     def parse_input(self, X):
         """Parse and create features for the `subgraph_matching` kernel.


### PR DESCRIPTION
Fixes an output shape issue in `SubgraphMatching.pairwise_operation`. Ensures the result is flattened to a 1D array for consistent downstream processing.
