### PR TITLE
Fix VertexHistogram sparse dtype for scipy compatibility

### DIFF
--- a/grakel/kernels/vertex_histogram.py
+++ b/grakel/kernels/vertex_histogram.py
@@ -136,7 +136,7 @@ class VertexHistogram(Kernel):
                     (data, (rows, cols)),
                     shape=(ni, len(labels)),
                     copy=False,
-                    dtype=">f8",
+                    dtype="float64",
                 )
             else:
                 # Initialise the feature matrix
@@ -149,7 +149,7 @@ class VertexHistogram(Kernel):
                         (data, (rows, cols)),
                         shape=(ni, len(labels)),
                         copy=False,
-                        dtype=">f8",
+                        dtype="float64",
                     )
 
             if ni == 0:


### PR DESCRIPTION
Use dtype="float64" instead of dtype=">f8" in csr_matrix() so that scipy.sparse accepts the matrix (scipy 1.17.0 does not support >f8). Fix #125 